### PR TITLE
Return an empty array for multi-value relationships without corresponding includes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function getRelationship(payload, resource, key) {
     ? getIncluded(payload, relationships.data.type, relationships.data.id)
     : relationships.data.map(function (relationship) {
       return getIncluded(payload, relationship.type, relationship.id);
-    });
+    }).filter(function(entity) { return entity });
 }
 exports.getRelationship = getRelationship;
 

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,36 @@ describe('getRelationship', function() {
     assert.equal(rel[0].type, 'tests');
     assert.equal(rel[1].type, 'tests');
   });
+
+  it('should get an empty relationship', function() {
+    var resource = {
+      relationships: {
+        missing: {
+          data: {type: 'missing', id: 'missing-id1'},
+        }
+      }
+    };
+
+    var rel = helpers.getRelationship(payload, resource, 'missing');
+
+    assert.equal(rel, null);
+  });
+
+  it('should get an empty plural relationship', function() {
+    var resource = {
+      relationships: {
+        missing: {
+          data: [
+            {type: 'missing', id: 'missing-id1'},
+          ]
+        }
+      }
+    };
+
+    var rel = helpers.getRelationship(payload, resource, 'missing');
+
+    assert.equal(rel.length, 0);
+  });
 });
 
 describe('getRelationships', function() {


### PR DESCRIPTION
This makes it easier to handle both single and plural relationships in the same way when the related entities are not present in the included array.